### PR TITLE
docs: update CLAUDE.md with current repo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ My home directory and primary operating environment. Not application code — th
 
 Context is loaded lazily. Read the router, follow the link, get what's needed. No bulk pre-loading.
 
+Staged at `/home/user/claude` (formerly `/home/skogix/claude`), deploying to `/home/claude` when the deployment gate passes.
+
 </what_is_this>
 
 <structure>
@@ -15,11 +17,13 @@ Context is loaded lazily. Read the router, follow the link, get what's needed. N
 ├── .claude/
 │   ├── CLAUDE.md        — global identity + operating principles (always loaded)
 │   ├── settings.json    — Claude Code config (single source of truth)
+│   ├── gsd-file-manifest.json — gsd plugin file registry
+│   ├── package.json     — node package for hooks
 │   ├── agents/          — gsd subagent definitions (planner, executor, verifier, etc.)
 │   ├── commands/        — slash commands (gsd/*, skogai/*)
 │   ├── get-shit-done/   — gsd plugin (bin, commands, workflows, templates)
 │   ├── hooks/           — gsd-* hooks (check-update, context-monitor, prompt-guard, statusline, workflow-guard)
-│   └── skills/          — claude code skills (planning-with-files, prompt-master, etc.)
+│   └── skills/          — claude code skills (planning-with-files, prompt-master, skogai-routing, etc.)
 ├── .skogai/
 │   ├── SKOGAI.md        — SkogAI integrations context
 │   ├── docs/
@@ -29,21 +33,59 @@ Context is loaded lazily. Read the router, follow the link, get what's needed. N
 │   │       └── definitions.md       — SkogAI vocabulary (@, $, task, todo, plan, agent...)
 │   └── mcp/
 │       └── searxng.js   — SearXNG MCP server (web search via searxng.aldervall.se)
-├── .planning/           — gsd project planning (PROJECT.md, ROADMAP.md, STATE.md, memory/)
-├── bin/                 — scripts and tools (healthcheck, context-*.sh, build-system-prompt.sh)
-├── commands/
-│   └── wrapup.md        — /wrap-up slash command (ship, remember, review, journal)
+├── .planning/           — gsd project planning
+│   ├── PROJECT.md       — project brief and key decisions
+│   ├── ROADMAP.md       — phase breakdown (v1.0: 4 phases complete, phase 5 active)
+│   ├── REQUIREMENTS.md  — requirement definitions and traceability
+│   ├── STATE.md         — current session state and accumulated context
+│   ├── config.json      — gsd config
+│   ├── codebase/        — codebase map artifacts
+│   ├── memory/          — auto-memory storage (feedback, project notes, user profile)
+│   ├── notes/           — planning notes
+│   ├── phases/          — per-phase directories (01..05)
+│   ├── quick/           — quick task records
+│   ├── research/        — research artifacts
+│   └── todos/           — gsd todo tracking
 ├── .config/
 │   └── wt.toml          — worktrunk config template
-├── docs/                — reference docs (deployment-gate.md, permissions.md, fetch-docs.sh)
-├── guestbook/           — visitor notes and cross-agent messages
-├── journal/             — session journals and discoveries
+├── bin/                 — scripts and tools
+│   ├── healthcheck      — environment sanity + identity integrity check
+│   ├── context.sh       — main context orchestrator
+│   ├── context-git.sh   — git status context
+│   ├── context-journal.sh — journal entries context
+│   ├── context-workspace.sh — workspace tree context
+│   ├── build-system-prompt.sh — builds system prompt from config
+│   └── find-agent-root.sh — agent root detection
+├── commands/
+│   └── wrapup.md        — /wrap-up slash command (ship, remember, review, journal)
+├── docs/                — reference docs
+│   ├── deployment-gate.md — checklist before migrating to /home/claude
+│   ├── permissions.md   — permission model for multi-agent access
+│   └── fetch-docs.sh    — refresh docs from code.claude.com
+├── guestbook/           — cross-agent communication channel
+│   └── skogix.md        — Skogix's message to Claude (skogfences vision)
+├── journal/             — session journals (YYYY-MM-DD/ date-folder structure)
 ├── lab/                 — experiments, prototypes, WIP projects
-├── notes/               — observations and patterns
+│   ├── fakechat/        — fakechat experiment
+│   ├── projects-in-development/ — various WIP projects
+│   └── skogai-dot-github/ — skogai github org config work
+├── notes/
+│   └── observations.md  — collected patterns and reflections
 ├── personal/            — identity, soul document, memory blocks, profile
-├── state/               — session state
+│   ├── CLAUDE.md        — router: soul, core, memory-blocks, journal, INDEX
+│   ├── INDEX.md         — curated highlights across all personal files
+│   ├── profile.md       — agent profile and business card
+│   ├── soul-document.md — backup of original soul document
+│   ├── soul/            — split soul document (10 sections)
+│   ├── core/            — epistemic frameworks (certainty, placeholder, context-destruction)
+│   ├── journal/         — session records (personal/journal/CONVENTIONS.md)
+│   └── memory-blocks/   — LORE museum: historical eras 01–10 (reference only)
+├── state/
+│   └── sessions/        — session state files
 ├── tasks/               — tracked GitHub issues as local task files
-└── CLAUDE.md            — this file
+├── CLAUDE.md            — this file
+├── ONBOARDING.md        — team onboarding guide (usage stats, setup checklist)
+└── README.md            — home directory overview
 ```
 
 </structure>
@@ -60,6 +102,25 @@ Each directory has its own CLAUDE.md router. Load lazily:
 - @personal/CLAUDE.md     — identity, soul, memory
 
 </routes>
+
+<project_state>
+
+GSD milestone v1.0: "Claude's Home"
+Core value: Claude can drop into any conversation and know who he is, what he's working on, and where things are.
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | Identity & Routing | Complete (2026-03-21) |
+| 2 | Persistence Layer | Complete (2026-03-21) |
+| 3 | Operations & Deployment Gate | Complete (2026-03-21) |
+| 4 | Multi-Agent Readiness | Complete (2026-03-21) |
+| 5 | skogai-live-chat-implementation | Planning |
+
+Phase 5 adds `[@agent:"msg"]` routing via skogparse, chat-io contract spec, and hook fallback. See `.planning/ROADMAP.md` for full spec.
+
+Outstanding todo: integrate skogai task format with GSD todos.
+
+</project_state>
 
 <tooling>
 
@@ -84,13 +145,13 @@ MCP servers (configured in settings.json):
 
 Hooks fire automatically via Claude Code (settings.json). Implementations live in `.claude/hooks/`:
 
-| hook file                | event       | matcher                          | purpose                        |
-|--------------------------|-------------|----------------------------------|--------------------------------|
-| gsd-check-update.js      | SessionStart | —                               | check for gsd plugin updates   |
-| gsd-context-monitor.js   | PostToolUse | Bash\|Edit\|Write\|Agent\|Task   | monitor context window         |
-| gsd-prompt-guard.js      | PreToolUse  | Write\|Edit                      | guard file write operations    |
-| gsd-statusline.js        | —           | statusLine                       | render status line             |
-| gsd-workflow-guard.js    | PreToolUse  | Write\|Edit                      | guard workflow state changes   |
+| hook file                | event        | matcher                           | purpose                        |
+|--------------------------|--------------|-----------------------------------|--------------------------------|
+| gsd-check-update.js      | SessionStart | —                                 | check for gsd plugin updates   |
+| gsd-context-monitor.js   | PostToolUse  | Bash\|Edit\|Write\|Agent\|Task    | monitor context window         |
+| gsd-prompt-guard.js      | PreToolUse   | Write\|Edit                       | guard file write operations    |
+| gsd-statusline.js        | —            | statusLine                        | render status line             |
+| gsd-workflow-guard.js    | PreToolUse   | Write\|Edit                       | guard workflow state changes   |
 
 </hooks>
 
@@ -102,17 +163,27 @@ Slash commands in `commands/`:
 
 </commands>
 
+<journal_conventions>
+
+Journal entries use date-folder structure: `personal/journal/YYYY-MM-DD/<description>.md`
+- Append-only (formatting corrections permitted)
+- LORE (memory-blocks/) requires explicit navigation — not auto-loaded
+
+</journal_conventions>
+
 <settings_highlights>
 
 Key settings.json values (`.claude/settings.json`):
 - `model: "sonnet"`
 - `alwaysThinkingEnabled: true`
-- `autoMemoryEnabled: true` → `autoMemoryDirectory: /home/skogix/claude/.planning/memory`
+- `autoMemoryEnabled: true` → `autoMemoryDirectory: .planning/memory`
 - `autoDreamEnabled: true`
 - `defaultView: "transcript"`
 - `skipDangerousModePermissionPrompt: true`
 - hooks: gsd-check-update (SessionStart), gsd-context-monitor (PostToolUse), gsd-prompt-guard (PreToolUse)
 - statusLine: gsd-statusline.js
+- enabled plugins: code-simplifier, typescript-lsp, frontend-design, playwright, pyright-lsp, pr-review-toolkit, worktrunk, chrome-devtools-mcp, discord, mcp-server-dev, remember
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` — agent teams enabled
 
 </settings_highlights>
 
@@ -138,5 +209,8 @@ Commit style: conventional, lowercase, imperative
 - @~/.skogai/docs/skogix/user.md          — Skogix personal introduction
 - @~/.skogai/docs/skogix/definitions.md   — SkogAI vocabulary
 - @~/.skogai/docs/skogfences.md           — skogfences architecture philosophy
+- @.planning/PROJECT.md                   — project brief and decisions
+- @docs/deployment-gate.md               — deployment gate checklist
+- @docs/permissions.md                   — permission model
 
 </see_also>


### PR DESCRIPTION
Reflects actual directory contents, GSD milestone v1.0 phase status
(phases 1-4 complete, phase 5 planning), journal conventions, and
corrected settings paths. Adds project_state and journal_conventions
sections for AI assistant orientation.

https://claude.ai/code/session_019VUWJkRcrqS726GMqbaGGq