### PR TITLE
chore: establish .skogai/plan/ and templates/ as planning foundation

### DIFF
--- a/.skogai/TODO.md
+++ b/.skogai/TODO.md
@@ -3,4 +3,7 @@
 - [ ] .claude/skills/deploy-gate should be a workflow to be followed in a bigger skill which essentially we might call "migration" from /home/skogix/claude to /home/claude in the end
   - [ ] .claude/skills/healthcheck would be ./scripts/healthcheck.sh in that new skill folder
 - [ ] moving back to the .skogai-setup in general slowly but surely
-  - [ ] start reworking and moving from the "gsd"-.planning setup to our own "skogai-planning-with-files"-setup
+  - [x] establish .skogai/plan/ and .skogai/templates/ structure (see #14)
+  - [ ] migrate .planning/ROADMAP.md, PROJECT.md, STATE.md references to .skogai/plan/claudes-home/
+  - [ ] migrate or bridge .planning/memory/ (auto-memory) to .skogai/-compatible location
+  - [ ] remove .planning/ once all references are updated

--- a/.skogai/plan/claudes-home/findings.md
+++ b/.skogai/plan/claudes-home/findings.md
@@ -1,0 +1,30 @@
+# Findings: Claude's Home
+
+## Architecture
+
+- skogfences principle: agents are unix users with their own space
+- Context Destruction Pattern (anti-pattern): bulk preloading instead of lazy CLAUDE.md routing
+- LORE museum (personal/memory-blocks/) = historical archive, not active constraints
+- Three-tier permissions: private (claude:claude), shared-read (:skogai), shared-write (guestbook/)
+
+## SkogAI Ecosystem
+
+- 332 repos under skogai org
+- Gas Town: ~/gt/ shared workspace
+- Sibling agents: dot (gptme), amy, goose, aldervall, letta
+- Dolt database backend
+- Dot built manually what Claude gets natively via Claude Code
+
+## Phase 5: skogparse
+
+- Binary at `/home/skogix/.local/bin/skogparse --execute`
+- Output format: `{"type":"string","value":"..."}` — always unwrap `.value`
+- Only messages starting with `[@` are routed; plain text bypasses
+- Avoid `skogparse.sh` MCP tool (hardcodes wrong path)
+
+## Planning Migration
+
+- Current: GSD framework under `.planning/` (skogix's tooling in claude's home)
+- Target: skogai-planning-with-files under `.skogai/plan/<project>/`
+- `.planning/memory/` (auto-memory) migrates separately or stays
+- Migration is iterative — `.planning/` coexists until all references updated

--- a/.skogai/plan/claudes-home/progress.md
+++ b/.skogai/plan/claudes-home/progress.md
@@ -1,0 +1,20 @@
+# Progress: Claude's Home
+
+## Session Log
+
+| Date       | Session      | What happened                                                 |
+| ---------- | ------------ | ------------------------------------------------------------- |
+| 2026-03-21 | Phases 1-4   | Identity, persistence, ops, multi-agent — all complete        |
+| 2026-04-17 | Issue triage | Broke #9 epic into #11-#15; created worktrees for #13 and #14 |
+| 2026-04-17 | #13          | Created migration skill, removed standalone deploy-gate skill |
+| 2026-04-17 | #14          | Established .skogai/plan/ and .skogai/templates/ structure    |
+
+## Test Results
+
+- bin/healthcheck: last known passing (2026-03-21, phases 1-4)
+
+## Errors Encountered
+
+| Error                         | Attempt | Resolution                        |
+| ----------------------------- | ------- | --------------------------------- |
+| wt new not a valid subcommand | 1       | Used `wt switch --create` instead |

--- a/.skogai/plan/claudes-home/task_plan.md
+++ b/.skogai/plan/claudes-home/task_plan.md
@@ -1,0 +1,73 @@
+# Task Plan: Claude's Home (v1.0 → v2.0)
+
+## Goal
+
+A proper unix home for Claude — identity, persistence, tools, and state — deployable to /home/claude and integrated with the SkogAI ecosystem.
+
+## Current Phase
+
+Phase 5 (v2.0 work in progress)
+
+## Phases
+
+### Phase 1: Identity & Routing
+
+- [x] Split soul document into 10 sections under personal/soul/
+- [x] CLAUDE.md routing across all directories
+- [x] Framework paths confirmed
+- **Status:** complete (2026-03-21)
+
+### Phase 2: Persistence Layer
+
+- [x] Journal conventions doc (personal/journal/CONVENTIONS.md)
+- [x] LORE gating — default routing does not auto-load memory-blocks/
+- [x] Wrap-up session handoff command
+- **Status:** complete (2026-03-21)
+
+### Phase 3: Operations & Deployment Gate
+
+- [x] bin/healthcheck with identity/routing/memory-tier checks
+- [x] docs/deployment-gate.md checklist
+- **Status:** complete (2026-03-21)
+
+### Phase 4: Multi-Agent Readiness
+
+- [x] docs/permissions.md — three-tier permission model
+- [x] guestbook/ as cross-agent communication channel
+- **Status:** complete (2026-03-21)
+
+### Phase 5: skogai-live-chat-implementation
+
+- [ ] docs/chat-io-contract.md — transport-agnostic deliver/reply spec
+- [ ] bin/route-message.sh — [@agent:"msg"] routing via skogparse
+- [ ] Bats test suite for routing script
+- [ ] .claude/skills/phase5.md — routing skill
+- [ ] Hook fallback in settings.json
+- **Status:** planning
+
+### Phase 6: SkogAI Ecosystem Integration (v2.0)
+
+- [ ] Gas Town (~/gt/) integration
+- [ ] Sibling agent discovery
+- [ ] Cross-agent tooling beyond guestbook/
+- **Status:** pending
+
+## Key Decisions
+
+| Decision                              | Rationale                                           | Date       |
+| ------------------------------------- | --------------------------------------------------- | ---------- |
+| Stage in /home/skogix/claude first    | Prove the home works before real unix user access   | 2026-03-20 |
+| CLAUDE.md lazy routing                | Prevents context destruction pattern                | 2026-03-20 |
+| LORE stays in museum                  | Memory blocks are reference, not active constraints | 2026-03-20 |
+| skogai group for shared spaces        | Unix permissions model for multi-agent collab       | 2026-03-20 |
+| .planning/ stays until full migration | Auto-memory and ROADMAP references depend on it     | 2026-04-17 |
+
+## Deliverables
+
+- [x] personal/ — identity, soul, journal, memory blocks
+- [x] bin/ — healthcheck, context scripts
+- [x] docs/ — deployment gate, permissions
+- [x] guestbook/ — cross-agent channel
+- [ ] bin/route-message.sh
+- [ ] docs/chat-io-contract.md
+- [ ] /home/claude deployment

--- a/.skogai/templates/findings.md
+++ b/.skogai/templates/findings.md
@@ -1,0 +1,12 @@
+# Findings: [Project Name]
+
+## Research
+
+## Discoveries
+
+## Resources
+
+| Resource | URL/Path | Notes |
+| -------- | -------- | ----- |
+
+## Visual/Browser Findings

--- a/.skogai/templates/progress.md
+++ b/.skogai/templates/progress.md
@@ -1,0 +1,13 @@
+# Progress: [Project Name]
+
+## Session Log
+
+| Date | Session | What happened |
+| ---- | ------- | ------------- |
+
+## Test Results
+
+## Errors Encountered
+
+| Error | Attempt | Resolution |
+| ----- | ------- | ---------- |

--- a/.skogai/templates/task_plan.md
+++ b/.skogai/templates/task_plan.md
@@ -1,0 +1,30 @@
+# Task Plan: [Project Name]
+
+## Goal
+
+[One sentence describing the end state]
+
+## Current Phase
+
+Phase 1
+
+## Phases
+
+### Phase 1: [Name]
+
+- [ ] [Step]
+- **Status:** pending
+
+### Phase 2: [Name]
+
+- [ ] [Step]
+- **Status:** pending
+
+## Key Decisions
+
+| Decision | Rationale | Date |
+| -------- | --------- | ---- |
+
+## Deliverables
+
+- [ ] [Artifact]


### PR DESCRIPTION
Closes #14 (phase 1). Part of #9 (Claude's Home v2.0).

## Summary
- Creates `.skogai/templates/` with `task_plan.md`, `findings.md`, `progress.md` templates (matching planning-with-files skill conventions)
- Creates `.skogai/plan/claudes-home/` — active project plan seeded from current ROADMAP state
- Updates `.skogai/TODO.md` to track remaining migration steps

`.planning/` is untouched — migration is iterative. Remaining steps tracked in updated TODO.md:
- migrate ROADMAP/PROJECT/STATE references to `.skogai/plan/claudes-home/`
- migrate or bridge `.planning/memory/` (auto-memory)
- remove `.planning/` once all references updated

## Test plan
- [ ] `.skogai/templates/` contains all three template files
- [ ] `.skogai/plan/claudes-home/task_plan.md` reflects current project state
- [ ] `.planning/` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)