### PR TITLE
docs: add root AGENTS.md for non-Claude agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+Codex/agent instructions for this repository.
+
+## Purpose
+
+This repository is a personal workspace (not a single app). Most context is documented in `CLAUDE.md` router files across the tree. As an agent, prefer loading the nearest `CLAUDE.md` for the area you are editing.
+
+## Scope and routing
+
+- Start with `./CLAUDE.md` for top-level orientation.
+- Before changing files in a subdirectory, check whether that directory has its own `CLAUDE.md` and follow it.
+- If a nested `AGENTS.md` exists, it overrides this file for that subtree.
+
+## Editing guidelines
+
+- Keep changes minimal and focused; avoid broad refactors unless requested.
+- Preserve the repository's structure as a workspace + knowledge base.
+- Prefer additive documentation updates over rewriting historical notes.
+- Do not delete or rewrite journal/history-style files unless explicitly requested.
+
+## Validation
+
+- For documentation-only changes, run lightweight checks (for example, `git diff --check`).
+- For code changes, run the smallest relevant test/lint commands documented in the nearest context file.
+
+## Commit conventions
+
+- Use conventional commits in lowercase imperative style:
+  - `docs:` for documentation updates
+  - `chore:` for maintenance/config
+  - `feat:` for new capabilities
+  - `fix:` for bug fixes
+
+## Notes
+
+- Existing `CLAUDE.md` files are still canonical context artifacts for this repo.
+- This `AGENTS.md` exists to make non-Claude coding agents work smoothly in the same workspace.


### PR DESCRIPTION
### Motivation
- Provide a root-level `AGENTS.md` so Codex/other non-Claude coding agents have explicit, minimal guidance for working in this repository and know to consult nearby `CLAUDE.md` routers for context.

### Description
- Add `AGENTS.md` at the repository root with purpose, scope/routing rules (prefer the nearest `CLAUDE.md`, nested `AGENTS.md` overrides), editing guidelines, validation guidance, commit conventions, and notes to align non-Claude agents with existing workspace practices.

### Testing
- Ran `git diff --check` to validate this documentation-only change and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d23be5a48331b9835cf117e185bc)