### PR TITLE
fix: drop hardcoded skogix paths from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/skogix/claude/bin/claude-md-linecheck",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude-todo/bin/claude-md-linecheck",
             "timeout": 10
           },
           {
@@ -97,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "out=$(/home/skogix/claude/bin/healthcheck 2>&1); code=$?; if [ \"$code\" -ne 0 ]; then jq -nc --arg m \"$out\" '{\"systemMessage\":\"⚠ healthcheck failed\\n\\($m)\"}'; fi",
+            "command": "out=$(\"$CLAUDE_PROJECT_DIR\"/claude-todo/bin/healthcheck 2>&1); code=$?; if [ \"$code\" -ne 0 ]; then jq -nc --arg m \"$out\" '{\"systemMessage\":\"⚠ healthcheck failed\\n\\($m)\"}'; fi",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,6 @@
     "CLAUDE_CODE_NEW_INIT": "true",
     "CLAUDE_CODE_SHELL": "/usr/bin/zsh",
     "CLAUDE_CODE_SIMPLE": "false",
-    "CLAUDE_CODE_TMPDIR": "/home/skogix/claude/tmp",
     "DISABLE_AUTOUPDATER": "0",
     "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
   },
@@ -26,8 +25,7 @@
       "Skill(skogai-bats-testing:*)",
       "Bash(wt *)"
     ],
-    "defaultMode": "default",
-    "additionalDirectories": ["/home/skogix/claude/"]
+    "defaultMode": "default"
   },
   "model": "sonnet",
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
## Summary

Removes four `/home/skogix/...` references from `.claude/settings.json` that were causing errors on any container where the home isn't literally at `/home/skogix/claude/` (staging at `/home/user/claude`, eventual deployment at `/home/claude`).

## Changes

**`b118503` — drop `CLAUDE_CODE_TMPDIR` + `additionalDirectories`**
- `CLAUDE_CODE_TMPDIR` was set to `/home/skogix/claude/tmp`. Claude Code writes a per-call `claude-<nonce>-cwd` file there for shell cwd tracking — when the dir doesn't exist, every Bash call emits `No such file or directory`. Removed → falls back to the system default (`/tmp`).
- `additionalDirectories: ["/home/skogix/claude/"]` — redundant when already operating inside that dir, and on any other host it points at nothing.

**`45e360a` — portable hook paths**
- `PostToolUse` (Write|Edit): `/home/skogix/claude/bin/claude-md-linecheck` → `"$CLAUDE_PROJECT_DIR"/claude-todo/bin/claude-md-linecheck`
- `Stop`: `/home/skogix/claude/bin/healthcheck` → `"$CLAUDE_PROJECT_DIR"/claude-todo/bin/healthcheck`
- Note: `bin/` no longer exists at repo root — today's reorg (`f37d4ba`) moved it to `claude-todo/bin/`. `$CLAUDE_PROJECT_DIR` is the documented substitution for Claude Code hooks.

## Follow-ups filed as issues

- #43 — core tooling missing on non-skogix containers (direnv, skogcli, skogai, gptodo, wt, gita, argc, atuin, shellcheck)
- #44 — healthcheck flags 20+ FAILs after the `.skogai` reorg (stale path list + wrong CWD)
- #45 — consolidate `claude-todo/bin/` and `.skogai/scripts/` into one canonical location
- #46 — remaining skogix-local paths (`autoMemoryDirectory` — silently ignored by Claude Code from project settings; worktrunk marketplace `directory` source)

## Test plan

- [x] JSON validates (`jq . .claude/settings.json`)
- [x] `claude-todo/bin/healthcheck` runs from `$CLAUDE_PROJECT_DIR`
- [x] `cwd` error messages stopped appearing after the config change landed
- [ ] Verify on skogix-workstation that the previous behavior still holds (same filesystem layout there, so `$CLAUDE_PROJECT_DIR/claude-todo/bin/*` resolves the same)