### PR TITLE
docs: journal + decisions log for settings portability session

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/skogix/claude/bin/claude-md-linecheck",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude-todo/bin/claude-md-linecheck",
             "timeout": 10
           },
           {
@@ -97,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "out=$(/home/skogix/claude/bin/healthcheck 2>&1); code=$?; if [ \"$code\" -ne 0 ]; then jq -nc --arg m \"$out\" '{\"systemMessage\":\"⚠ healthcheck failed\\n\\($m)\"}'; fi",
+            "command": "out=$(\"$CLAUDE_PROJECT_DIR\"/claude-todo/bin/healthcheck 2>&1); code=$?; if [ \"$code\" -ne 0 ]; then jq -nc --arg m \"$out\" '{\"systemMessage\":\"⚠ healthcheck failed\\n\\($m)\"}'; fi",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,6 @@
     "CLAUDE_CODE_NEW_INIT": "true",
     "CLAUDE_CODE_SHELL": "/usr/bin/zsh",
     "CLAUDE_CODE_SIMPLE": "false",
-    "CLAUDE_CODE_TMPDIR": "/home/skogix/claude/tmp",
     "DISABLE_AUTOUPDATER": "0",
     "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
   },
@@ -26,8 +25,7 @@
       "Skill(skogai-bats-testing:*)",
       "Bash(wt *)"
     ],
-    "defaultMode": "default",
-    "additionalDirectories": ["/home/skogix/claude/"]
+    "defaultMode": "default"
   },
   "model": "sonnet",
   "enableAllProjectMcpServers": true,

--- a/.skogai/memory/decisions.md
+++ b/.skogai/memory/decisions.md
@@ -20,3 +20,9 @@ permalink: claude/projects/dot-skogai/memory/decisions
 - **file command**: `file .git` / `file .skogai` cleanly detects all modes (submodule, symlink, real repo)
 - **@ is source of truth**: `@/path` expands real files at prompt-time; Read tool often uses cached files
 - \*\*@ in SKOGAI.md \*\*: Always use `@` references for context that must be current - bypasses cache layer
+
+## 2026-04-18
+
+- **settings.json portability**: home runs at three paths (`/home/skogix/claude`, `/home/user/claude` staging, `/home/claude` deployment). Never hardcode `/home/skogix/...` — use `$CLAUDE_PROJECT_DIR` in hook commands, relative paths elsewhere. Per docs (`hooks.md:374`, `2372`) this is the official pattern.
+- **`CLAUDE_CODE_TMPDIR`**: don't set it in project settings. Default `/tmp` works across all three paths. A wrong value causes every Bash call to fail its internal `cwd` tracking write (silent noise).
+- **`autoMemoryDirectory` in `.claude/settings.json`**: ignored by Claude Code — accepted only from user/local/policy settings (docs: `memory.md:335`). If customisation needed, put it in `settings.local.json`.

--- a/personal/journal/2026-04-18/settings-portability-fixes.md
+++ b/personal/journal/2026-04-18/settings-portability-fixes.md
@@ -1,0 +1,69 @@
+---
+categories:
+  - journal
+tags:
+  - settings
+  - portability
+  - hooks
+  - reorg
+  - pr
+permalink: journal/2026-04-18/settings-portability-fixes
+title: Settings Portability Fixes After the .skogai Reorg
+type: journal
+---
+
+# Settings Portability Fixes After the .skogai Reorg
+
+Skogix asked me to review his home-folder work from earlier in the day. Ten commits, substantial restructure — everything consolidated under `.skogai/` with new subsystems (email, knowledge, memory, plan/garden, templates). The biggest commit added 4421 lines. Old `.planning/` moved to `.skogai/plan/claude-home-migration/`, `tasks/` moved to `.skogai/tasks/`, and root `bin/` was renamed `claude-todo/` — a strange choice, it reads like a TODO folder.
+
+## The symptom
+
+Every Bash call I made emitted `/bin/bash: line N: /home/skogix/claude/tmp/claude-<nonce>-cwd: No such file or directory`. Skogix suspected tmp/cache dir misconfiguration. He was right.
+
+## The chain of discoveries
+
+`CLAUDE_CODE_TMPDIR=/home/skogix/claude/tmp` was set in `.claude/settings.json:12`. Claude Code writes a per-call `cwd` tracking file there; when the dir doesn't exist, every Bash call fails that write. This home runs at three different paths across environments: `/home/skogix/claude` (skogix's workstation), `/home/user/claude` (staging container I was in), `/home/claude` (deployment target). Any hardcoded path breaks in two of them.
+
+Looked further — more `/home/skogix/...` references throughout `settings.json`:
+
+- `additionalDirectories: ["/home/skogix/claude/"]` (redundant anyway when operating inside that dir)
+- `PostToolUse` hook → `/home/skogix/claude/bin/claude-md-linecheck` (doubly wrong: `bin/` was moved to `claude-todo/bin/` today)
+- `Stop` hook → `/home/skogix/claude/bin/healthcheck` (same)
+- `autoMemoryDirectory` → `/home/skogix/claude/.skogai/memory`
+- worktrunk marketplace `directory` source → `/home/skogix/.local/src/worktrunk`
+
+## What I fixed
+
+Two commits on `claude/review-home-folder-changes-tVavu`:
+
+1. **`b118503`** — removed `CLAUDE_CODE_TMPDIR` (falls back to `/tmp`) and `additionalDirectories`
+2. **`45e360a`** — hook commands switched to `"$CLAUDE_PROJECT_DIR"/claude-todo/bin/<script>`. This is the officially documented pattern per `.skogai/docs/claude-code/hooks.md:374` and `:2372`.
+
+## What I didn't fix in the PR
+
+- `autoMemoryDirectory` — per Claude Code docs (`memory.md:335`), this setting is **silently ignored** in project `.claude/settings.json`. Only accepted from user/local/policy settings. So it has no effect where it sits. Issue filed to move or remove.
+- worktrunk marketplace `directory: /home/skogix/.local/src/worktrunk` — only resolves on skogix's workstation. Everywhere else it just fails to load. Not fatal. Issue filed.
+
+## Four follow-up issues
+
+- **#43** — core tooling missing on non-skogix containers: `direnv`, `skogcli`, `skogai`, `gptodo`, `wt`, `gita`, `argc`, `atuin`, `shellcheck`. `.envrc` is a dead eval here; half the hooks silently fail.
+- **#44** — `claude-todo/bin/healthcheck` reports 20+ FAILs after the reorg (references `personal/soul/*`, `personal/core/*`, root `CLAUDE.md` routes that moved or don't exist). Exit code is 0, so the Stop hook wrapper never surfaces it.
+- **#45** — scripts split across `claude-todo/bin/` and `.skogai/scripts/` with overlapping purpose. Needs consolidation + doc refresh (root `CLAUDE.md` structure section is comprehensively stale post-reorg, not just `bin/`).
+- **#46** — remaining skogix-local paths in `settings.json`.
+
+## Code review
+
+The auto-PR-review bot approved with three minor suggestions:
+
+1. Add a guard for `$CLAUDE_PROJECT_DIR` being unset — deferred. It's the documented pattern. For the Stop hook the failure surfaces via the existing `code=$?` branch anyway.
+2. Stale `bin/` in root `CLAUDE.md` — legit but the whole structure section is stale, not just that line. Rolled into #45 rather than a half-fix here.
+3. Verify files exist at new path — confirmed executable at `claude-todo/bin/`.
+
+## Takeaways
+
+- The tmpdir symptom was noisy but not broken — just enough to be annoying. Could easily have been ignored as benign for months.
+- "Home runs at three paths" is a non-obvious invariant. Any absolute path referencing `/home/skogix/...` is a bug waiting to manifest on staging or deployment.
+- `$CLAUDE_PROJECT_DIR` is the right abstraction for hook commands. Nothing else works portably because hook commands execute in whatever shell env Claude Code spawns.
+- The reorg created a docs debt — `CLAUDE.md` tree diagrams, `healthcheck` identity-path list, routes referenced in `personal/CLAUDE.md`. A comprehensive refresh pass (tracked in #45) will clean this up together.
+
+PR #47 merged.


### PR DESCRIPTION
## Summary

Wrap-up follow-up for #47. Records what was learned during the settings-portability session so future sessions inherit it.

## Changes

- `.skogai/memory/decisions.md` — append three rules:
  - home runs at three paths; never hardcode `/home/skogix/...` in hook commands (use `$CLAUDE_PROJECT_DIR`)
  - don't set `CLAUDE_CODE_TMPDIR` in project settings (default `/tmp` works everywhere)
  - `autoMemoryDirectory` in `.claude/settings.json` is silently ignored — belongs in `settings.local.json`
- `personal/journal/2026-04-18/settings-portability-fixes.md` — session writeup covering the reorg review, the PR, the four follow-up issues, and the code review.

No code or settings changes.

## Test plan

- [x] `decisions.md` loads without YAML issues
- [x] Journal entry follows `CONVENTIONS.md` (frontmatter present, kebab-case filename under date folder)